### PR TITLE
Add initial support for ternary operator.

### DIFF
--- a/lib/src/parser/grammar.dart
+++ b/lib/src/parser/grammar.dart
@@ -56,9 +56,11 @@ class BadgerGrammarDefinition extends GrammarDefinition {
     ref(arguments, false) &
     char("]");
 
-  ternaryOperator() => ref(expression) &
+  ternaryOperator() => ref(expressionItem) &
     whitespace().star() &
     char("?") &
+    whitespace().star() &
+    ref(expression) &
     whitespace().star() &
     char(":") &
     whitespace().star() &
@@ -104,7 +106,8 @@ class BadgerGrammarDefinition extends GrammarDefinition {
     ref(expression);
 
   variableReference() => ref(identifier);
-  expression() => (
+  expression() => ref(ternaryOperator) | ref(expressionItem);
+  expressionItem() => (
     (
       ref(anonymousFunction) |
       ref(emptyListDefinition) |


### PR DESCRIPTION
Thank you for your kind mail, it is indeed still day-time here in Switzerland :-)

Below a quick proposal as a pull request of your ternary operator. To avoid the recursion you prioritize the precedence of operators in different rules (first or-case on line 109), and when you don't find an operator you skip to the next precedence level (second or-case on line 109). Important is also important that the first reference in the operator itself you immediately skip to the next precedence level, otherwise you end up in a recursion. I suspect you will need this pattern a lot more as soon as you start to implement other operators with different priorities. There is a nice example for that in the PetitParser tests (https://github.com/petitparser/dart-petitparser/blob/master/test/core_test.dart#L1334).

I haven't tested my proposal deeply, but I suspect my code change does what you want.
