### PR TITLE
Some simple improvements/fixes to the parser

### DIFF
--- a/lib/src/parser/grammar.dart
+++ b/lib/src/parser/grammar.dart
@@ -127,7 +127,7 @@ class BadgerGrammarDefinition extends GrammarDefinition {
   NEWLINE() => pattern('\n\r');
 
   singleLineComment() => string('//')
-    & ref(NEWLINE).neg().star()
+    & any().starLazy(ref(NEWLINE))
     & ref(NEWLINE).optional();
 
   declarations() => ref(declaration).separatedBy(char("\n"));
@@ -348,7 +348,7 @@ class BadgerGrammarDefinition extends GrammarDefinition {
     ref(block);
 
   integerLiteral() => (
-    anyIn(["-", "+"]).optional() &
+    pattern("-+").optional() &
     digit().plus()
   ).flatten();
 
@@ -370,7 +370,7 @@ class BadgerGrammarDefinition extends GrammarDefinition {
   );
 
   doubleLiteral() => (
-    anyIn(["-", "+"]).optional() &
+    pattern("-+").optional() &
     digit().plus() &
     char(".") &
     digit().plus()
@@ -391,7 +391,7 @@ class BadgerGrammarDefinition extends GrammarDefinition {
     char("}");
 
   nativeCode() => string("```") &
-    pattern("^```").star().flatten() &
+    any().starLazy(string("```")).flatten() &
     string("```");
 
   mapEntry() => ref(expressionItem) &
@@ -418,12 +418,7 @@ class BadgerGrammarDefinition extends GrammarDefinition {
     pattern(_decodeTable.keys.join())
   ).flatten();
 
-  identifier() => (
-    pattern("A-Za-z_") | anyIn([
-      "\$",
-      "\u03A0", // Pi
-    ])
-  ).plus();
+  identifier() => pattern("A-Za-z_\$\u03A0").plus();
 
   BREAK() => ref(token, "break");
   CASE() => ref(token, "case");


### PR DESCRIPTION
This doesn't improve the situation much, but should help a tiny bit.

As you recognised, there is something wrong with the anonymous functions. I played a bit around with the ordering of the items in "expression" and "expressionItem". Things that can be cheaply rejected should come first, but then order also matters. I didn't dare to actually reorder some of the rules, because I am missing unit tests that would tell me exactly what parts of the langue I break.

One thing that is certainly slowing down the grammar are large overlapping productions like "anonymousFunction" and "simpleAnonymousFunction". They require to read a significant amount of input to be able to decide which function to take. Combining those into one with only the "->" and "=>" as the choice could help.

Similarly, the huge choice switches don't help for speed. Also I am not sure, if they implement what you intend your grammar to do? In fact they parse expressions from left-to-right, no mater the precedence of the mathematical operators. In any case, I suggest that you stack your checks either using the pattern described here (https://github.com/petitparser/dart-petitparser/blob/master/test/core_test.dart#L1334) or use the expression builder as part of your grammar (https://github.com/petitparser/dart-petitparser/blob/master/test/core_test.dart#L1372). In either case you will end up with a much more efficient grammar.
